### PR TITLE
Improve violation path on assert message when validating arrays

### DIFF
--- a/src/Factory/ConstraintFactory.php
+++ b/src/Factory/ConstraintFactory.php
@@ -17,6 +17,7 @@ class ConstraintFactory
         foreach ($this->namespaces as $namespace) {
             $class = sprintf('%s\%s', $namespace, $constraintName);
 
+            // if class exists and is an instance of Constraint
             if (class_exists($class) && is_a($class, Constraint::class, true)) {
                 return new $class(...$arguments);
             }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -69,10 +69,11 @@ class Validator
         $violations = $this->validate($value, $name, $groups);
 
         if ($violations->count() > 0) {
-            $message = $violations->get(0)->getMessage();
+            $violation = $violations->get(0);
+            $message = $violation->getMessage();
 
             if ($name !== null) {
-                $message = sprintf('%s: %s', $name, $message);
+                $message = sprintf('%s: %s', $violation->getPropertyPath(), $message);
             }
 
             throw new ValidationFailedException($message, $value, $violations);

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -40,12 +40,10 @@ class ValidatorTest extends AbstractTestCase
 
     public function testValidate(): void
     {
-        // test fail
         $violations = $this->validator->validate(16);
         $this->assertInstanceOf(ConstraintViolationList::class, $violations);
         $this->assertCount(1, $violations);
 
-        // test success
         $violations = $this->validator->validate(18);
         $this->assertInstanceOf(ConstraintViolationList::class, $violations);
         $this->assertCount(0, $violations);
@@ -65,9 +63,7 @@ class ValidatorTest extends AbstractTestCase
 
     public function testIsValid(): void
     {
-        // test fail
         $this->assertFalse($this->validator->isValid(16));
-        // test success
         $this->assertTrue($this->validator->isValid(18));
     }
 
@@ -84,9 +80,7 @@ class ValidatorTest extends AbstractTestCase
     {
         Validator::addNamespace('ProgrammatorDev\FluentValidator\Test\Constraint');
 
-        // test fail
         $this->assertFalse(Validator::containsAlphanumeric()->isValid('!'));
-        // test success
         $this->assertTrue(Validator::containsAlphanumeric()->isValid('v4l1d'));
     }
 
@@ -94,12 +88,12 @@ class ValidatorTest extends AbstractTestCase
     {
         // by default, error is in English
         $violations = $this->validator->validate('');
-        $this->assertEquals('This value should not be blank.', $violations[0]->getMessage());
+        $this->assertEquals('This value should not be blank.', $violations->get(0)->getMessage());
 
         // set translator and then try again
         Validator::setTranslator(new Translator('pt'));
         // now error is in Portuguese
         $violations = $this->validator->validate('');
-        $this->assertEquals('Este valor não deveria ser vazio.', $violations[0]->getMessage());
+        $this->assertEquals('Este valor não deveria ser vazio.', $violations->get(0)->getMessage());
     }
 }


### PR DESCRIPTION
As an example, when validating an array with `collection` and a `name` was given, the assert message would not display the index in the array where the error occurred.

```php
$input = ['name' => ''];

Validator::collection([
  'name' => Validator::notBlank()->getConstraints()
])->assert($input, name: 'collection');
```

Would throw the following exception message `collection: This value should not be blank.`.
With the fix, returns `collection[name]: This value should not be blank.`.